### PR TITLE
Added missing import for enum34 to support 'from enum import Enum'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0
 h5py==2.6.0
+enum34==1.1.6


### PR DESCRIPTION
I haven't yet been able to test this out, but I will when I have access to the ROS environment again. Meanwhile, you can take a look at the fix.